### PR TITLE
Fix exception when it is top level function, add usage in README.md

### DIFF
--- a/Aphrodite.py
+++ b/Aphrodite.py
@@ -51,6 +51,9 @@ class AphroditeHook(idaapi.Hexrays_Hooks):
                 continue
             if cur_offset <= offset:
                 return i
+        # it is the root block of whole function
+        # just return the function's end line decrease 1
+        return len(ocode) - 1
 
     def abs_lnnum(self, line0, lnnum):
         self.log('get abs_lnnum @ {}'.format(lnnum))

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # AphroditeF5
-ida pro collapse plugin
+IDA pro collapse plugin
+
+# Usage
+In hex-rays window (usually called F5 window), at the left curly brackets line, double click mouse's left button.


### PR DESCRIPTION
1. When double click at the begin curly brackets of a function, there will be a NoneType exception.
2. Add a usage section in README.md.